### PR TITLE
Continue to static interface methods

### DIFF
--- a/LambdaExp/Inheritance/StaticInterfaceMethod.java
+++ b/LambdaExp/Inheritance/StaticInterfaceMethod.java
@@ -1,0 +1,13 @@
+package Inheritance;
+
+public interface StaticInterfaceMethod {
+    static int getJumpHeight(){//This method is assumed to be public and can not be inherited by an methods implementing the interface "StaticInterfaceMethod"
+        return 10;
+    }
+}
+class Stationary implements StaticInterfaceMethod{// a class can implement an interface
+    public void getJumpHeight(){
+        System.out.println(getJumpHeight());//this does not compile because there is no explicit refernce to the name of the interface like the below
+        System.out.println(StaticInterfaceMethod.getJumpHeight());
+    }
+}


### PR DESCRIPTION
I learned that to reference a static method, a reference to the name of the interface must be used 
If you try to access a method without an explicit reference to the name of the interface, the code will not compile